### PR TITLE
Use hat setting when minion is wearing oxygen mask

### DIFF
--- a/src/features/DuplicantLights/MinionLighting.cs
+++ b/src/features/DuplicantLights/MinionLighting.cs
@@ -51,11 +51,11 @@ namespace DarknessNotIncluded.DuplicantLights
         if (suitPrefab != null && suit?.isEquipped == true)
         {
           if (suitPrefab?.HasTag(GameTags.AtmoSuit) == true) return MinionLightType.AtmoSuit;
-          else if (suitPrefab?.HasTag(GameTags.JetSuit) == true) return MinionLightType.JetSuit;
-          else if (suitPrefab?.HasTag(GameTags.LeadSuit) == true) return MinionLightType.LeadSuit;
-          else return MinionLightType.Intrinsic;
+          if (suitPrefab?.HasTag(GameTags.JetSuit) == true) return MinionLightType.JetSuit;
+          if (suitPrefab?.HasTag(GameTags.LeadSuit) == true) return MinionLightType.LeadSuit;
         }
-        else if (hat?.StartsWith("hat_role_mining") == true)
+        
+        if (hat?.StartsWith("hat_role_mining") == true)
         {
           if (hat == "hat_role_mining1") return MinionLightType.Mining1;
           else if (hat == "hat_role_mining2") return MinionLightType.Mining2;


### PR DESCRIPTION
Version observed: v1.2.1

Observed behavior: when a minion is wearing a mining hat and a oxygen mask, the lighting looks like the default, so intrinsic (see picture attached).
![image](https://user-images.githubusercontent.com/132479697/236007818-fd83305b-2c4a-40cb-8775-9408fe3abab4.png)

Expected behavior: when a minion is wearing an oxygen mask, it is ignored and the lighting is determined by the hat. This is supported by the fact that the appearance clearly suggests that the oxygen mask does not cover the hat in any way.